### PR TITLE
simplified tiff-to-pdf etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Requires mktemp, imagemagick, xsane and pdftk.
 * -f <filename>: Filename for pdf output
 * -c : Scans colour PDFs
 * -q : Sets the JPEG-Quality a bit higher
-* -r <resolution>: default 150 dpi (up to 600 dpi possible)
+* -r <resolution>: Resolution (default 150 dpi, up to 600 dpi possible)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # kodakscan
-Bash-Script for usage with xsane and a Koak i65
-
+Bash-Script for usage with xsane and a Kodak i65.
+Requires mktemp, imagemagick, xsane and pdftk.
 
 ## Command line parameters
-* -f <filename>: Filenmae for pdf output
+* -f <filename>: Filename for pdf output
 * -c : Scans colour PDFs
 * -q : Sets the JPEG-Quality a bit higher
+* -r <resolution>: default 150 dpi (up to 600 dpi possible)

--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -23,7 +23,7 @@ done
 # Check if file is set
 if [[ ! "$FILE" ]]
 then
-	FILE="$(date +"%s").pdf"
+	FILE="$(date +"%F %H%M%S").pdf"
 fi
 
 echo Will output to file "$FILE"
@@ -40,8 +40,11 @@ convert $TMPFILE*.tiff $gs -quality $qual -density "$dpi"x"$dpi" -compress jpeg 
 if [[ ! -f $FILE ]]
 then
 	#File does not exist. This is easy
-	echo Creating new PDF $FILE
-	cp "$TMPFILE.all.pdf" "$FILE"
+	echo Creating new PDF $FILE and fixing title.
+	#creating tmpfile because pdftk's update_info apparently can't read inline
+	echo -en "InfoKey: Title\nInfoValue: $FILE\n" > $TMPFILE.title
+	#updating the title because "tmp.rvvk8ozNjn.pdf" just doesn't look good in the title bar, also moving the file away from tmp
+	pdftk $TMPFILE.all.pdf update_info $TMPFILE.title output "$FILE"
 else
 	#File exists. cat'ing files together
 	echo Appending to existing PDF $FILE

--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -2,18 +2,20 @@
 
 # Scans from a hard-coded scanner to a pdf in the current directory
 
-TMPFILE=$(tempfile)
+TMPFILE=$(mktemp)
 
 gs='-type Grayscale'
 qual='50%'
+dpi='150'
 
 # Get options
-while getopts ":f:cq" Option
+while getopts ":f:cqr:" Option
 do
   case $Option in
     f ) FILE=$OPTARG;;
-		c ) gs='';;
-		q ) qual='85%';;
+    c ) gs='';;
+    q ) qual='85%';;
+    r ) dpi=$OPTARG;;
   esac
 done
 
@@ -26,13 +28,13 @@ fi
 
 echo Will output to file "$FILE"
 
-#Scan file and create pdf
-scanimage  --format tiff -p --batch=$TMPFILE%04d.tiff --source 'ADF Duplex' --resolution 150
+#Scan pages and store .tiffs
+echo Starting scan...
+scanimage --format tiff -p --batch=$TMPFILE%04d.tiff --source 'ADF Duplex' --resolution $dpi
 
-#for f in $(ls $TMPFILE*.tiff | sort); do echo $f; convert -type Grayscale  -quality 50% $f $f.jpg; convert $f.jpg $f.jpg.pdf; done
-for f in $(ls $TMPFILE*.tiff | sort); do echo $f; convert $gs -quality $qual $f $f.jpg; convert -page A4 $f.jpg $f.jpg.pdf; done
-
-pdftk $(ls $TMPFILE*.tiff.jpg.pdf | sort) cat output $TMPFILE.all.pdf
+#use imagemagick to compress all tiffs and glue them to a single pdf
+echo Glueing pages...
+convert $TMPFILE*.tiff $gs -quality $qual -density "$dpi"x"$dpi" -compress jpeg $TMPFILE.all.pdf
 
 #Output to given file
 if [[ ! -f $FILE ]]


### PR DESCRIPTION
The script caused some pdfs to have weird sizes and white borders, this might be due to different imagemagick versions or sane. However, these changes seem to work just fine.

The tiff-to-pdf-part was reduced to a single line, thanks to drc. 

Scan resolution was parameterized.

Default Filename is now something semi useful and will also be written into pdf metadata (as long as it's not appended to another pdf).

Switched to mktemp from tempfile because the latter is deprecated and more often not available.

Also, fixed some typos.
