### PR TITLE
Add source selection and number of pages

### DIFF
--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -10,6 +10,7 @@ usage() {
   echo "  -c         Scan in color [default: gray scale]"
   echo "  -q         Set output JPEG quality to 85% [default: 50%]"
   echo "  -r RES     Set resolution in dpi [default 150 dpi]"
+  echo "  -# NUM     Number of pages to scan"
   echo
   echo "Source selection:"
   echo "  -s    Specify scan source: Normal | ADF Front | ADF Back | ADF Duplex"
@@ -24,9 +25,10 @@ gs='-type Grayscale'
 qual='50%'
 dpi='150'
 paper_source='ADF Duplex'
+page_count=''
 
 # Get options
-while getopts ":f:cqr:s:odnh" Option
+while getopts ":f:cqr:s:odn#:h" Option
 do
   case $Option in
     f ) FILE=$OPTARG;;
@@ -36,7 +38,8 @@ do
     s ) paper_source=$OPTARG;;
     o ) paper_source='ADF Front';;
     d ) paper_source='ADF Duplex';;
-    n ) paper_source='Normal';;
+    n ) paper_source='Normal'; page_count='--batch-count=1';;
+    '#' ) page_count="--batch-count=$OPTARG";;
     h ) usage; exit;;
   esac
 done
@@ -53,7 +56,7 @@ echo Will output to file "$FILE"
 
 #Scan pages and store .tiffs
 echo Starting scan...
-scanimage --format tiff -p --batch=$TMPFILE%04d.tiff --source "$paper_source" --resolution $dpi
+scanimage --format tiff -p --batch=$TMPFILE%04d.tiff $page_count --source "$paper_source" --resolution $dpi
 
 #use imagemagick to compress all tiffs and glue them to a single pdf
 echo Glueing pages...

--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -16,7 +16,7 @@ qual='50%'
 dpi='150'
 
 # Get options
-while getopts ":f:cqrh:" Option
+while getopts ":f:cqr:h" Option
 do
   case $Option in
     f ) FILE=$OPTARG;;

--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -5,24 +5,38 @@
 usage() {
   echo "scanKodak.sh [OPTIONS...]"
   echo
+  echo "General options:"
   echo "  -f FILE    Give output file name [default: \`date +%F %H%M%S\`]"
   echo "  -c         Scan in color [default: gray scale]"
   echo "  -q         Set output JPEG quality to 85% [default: 50%]"
   echo "  -r RES     Set resolution in dpi [default 150 dpi]"
+  echo
+  echo "Source selection:"
+  echo "  -s    Specify scan source: Normal | ADF Front | ADF Back | ADF Duplex"
+  echo "          [default: ADF Duplex]"
+  echo "  -o    Scan only front pages from feeder (shortcut for -s 'ADF Front')"
+  echo "  -d    Scan front and back pages from feeder (shortcut for -s 'ADF Duplex')"
+  echo "          [default]"
+  echo "  -n    Scan pages from flatbed (shortcut for -s 'Normal')"
 }
 
 gs='-type Grayscale'
 qual='50%'
 dpi='150'
+paper_source='ADF Duplex'
 
 # Get options
-while getopts ":f:cqr:h" Option
+while getopts ":f:cqr:s:odnh" Option
 do
   case $Option in
     f ) FILE=$OPTARG;;
     c ) gs='';;
     q ) qual='85%';;
     r ) dpi=$OPTARG;;
+    s ) paper_source=$OPTARG;;
+    o ) paper_source='ADF Front';;
+    d ) paper_source='ADF Duplex';;
+    n ) paper_source='Normal';;
     h ) usage; exit;;
   esac
 done
@@ -39,7 +53,7 @@ echo Will output to file "$FILE"
 
 #Scan pages and store .tiffs
 echo Starting scan...
-scanimage --format tiff -p --batch=$TMPFILE%04d.tiff --source 'ADF Duplex' --resolution $dpi
+scanimage --format tiff -p --batch=$TMPFILE%04d.tiff --source "$paper_source" --resolution $dpi
 
 #use imagemagick to compress all tiffs and glue them to a single pdf
 echo Glueing pages...


### PR DESCRIPTION
This originally started as "only scan front pages" to get rid of the blank back
pages, but in fact this can be generalized to allow scanning from every possible
source. 

Also users can now specify the number of pages to scan.
