### PR TITLE
Don't delete existing documents after scanimage exits with errors

### DIFF
--- a/scanKodak.sh
+++ b/scanKodak.sh
@@ -57,6 +57,10 @@ echo Will output to file "$FILE"
 #Scan pages and store .tiffs
 echo Starting scan...
 scanimage --format tiff -p --batch=$TMPFILE%04d.tiff $page_count --source "$paper_source" --resolution $dpi
+if [ ! -e $TMPFILE*.tiff ]; then
+	echo "Errors while scanning. Exiting without action."
+	exit 1
+fi
 
 #use imagemagick to compress all tiffs and glue them to a single pdf
 echo Glueing pages...


### PR DESCRIPTION
When the temporary TIFF file does not exist after the scanimage call, the `else` part in lines 79-83 tries to glue nonexisting pages to the original PDF output, effectively deleting the PDF.
